### PR TITLE
(#6) waitFor freezes for big files

### DIFF
--- a/src/main/kotlin/VideoVisitor.kt
+++ b/src/main/kotlin/VideoVisitor.kt
@@ -14,6 +14,7 @@ class VideoVisitor(private val rootDirectory: Path, private val outputDir: Path)
         if (!Files.exists(outputPath)) {
             println("Processing $file")
             val conversionProcess = ProcessBuilder("ffmpeg", "-i", "$file", "-b", "1000000", "$outputPath")
+                .inheritIO()
                 .start()
             conversionProcess.waitFor()
         } else {


### PR DESCRIPTION
It happens because output goes into a buffer. In former version
it was not directed enywhere and started to overflow. Now it's
inherited from the Java process and works correctly